### PR TITLE
docker: use node 21 and debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build environment
-FROM node:20-alpine as node_server
+FROM node:21.1.0-alpine as build_env
 WORKDIR /src
 # Copy entire project
 COPY . .
@@ -9,16 +9,16 @@ RUN yarn install --frozen-lockfile && yarn cache clean
 RUN yarn run build
 
 # production environment
-FROM node:20-alpine
+FROM node:21.1.0-alpine as runtime_env
 ENV NODE_ENV=production
 # Copy build output to working dir
 WORKDIR /app
-COPY --from=node_server /src/build ./
+COPY --from=build_env /src/build ./
 # HACK: THIS IS A WORKAROUND FOR MOCKED DATA
-COPY --from=node_server /src/data ./data
+COPY --from=build_env /src/data ./data
 # Copy required packages and app config
-COPY --from=node_server /src/yarn.lock ./
-COPY --from=node_server /src/package.json ./
+COPY --from=build_env /src/yarn.lock ./
+COPY --from=build_env /src/package.json ./
 RUN yarn install --frozen-lockfile --production && yarn cache clean
 RUN printenv
 CMD node ./index.js


### PR DESCRIPTION
Node 21 moves the native fetch api which we use from experimental support to stable. It also adds an experimental native ws library, see: https://nodejs.org/en/blog/announcements/v21-release-announce