### PR TITLE
 Inventory server-doc gaps and cross-link the new client-docs suite

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,3 +34,11 @@ All paths relative to `%USERPROFILE%\Code\bsf-refs\server-2013-java\`. Ordered b
 7. `db/game/0/schema.sql` plus numbered `apply.sql` migrations under `db/game/N/` — the original MySQL schema 88 as a target column set when adding SQLite tables. Not for direct port (MySQL → SQLite syntax differences).
 
 For a one-screen route-by-route map (`bsf-server` `services/*` ↔ Java `*Svc.java`), see [`bsf-server/docs/protocol-cross-reference.md`](./bsf-server/docs/protocol-cross-reference.md).
+
+## Client-side companion docs
+
+The `bsf-client/docs/` suite is the client-side counterpart to the server references above. The three highest-value entries:
+
+1. [`bsf-client/docs/wire-protocol.md`](./bsf-client/docs/wire-protocol.md) — every `/services/*` route from the client side: which `Txn` class issues it, what fields go on the wire, what response the client expects. Pairs row-by-row with [`bsf-server/docs/protocol-cross-reference.md`](./bsf-server/docs/protocol-cross-reference.md); three documented exceptions (`account/tutorial`, `roster/unit/variation`, `tourney/join`) are the only one-sided routes.
+2. [`bsf-client/docs/battle-engine.md`](./bsf-client/docs/battle-engine.md) — battle FSM states, entity-ID format (`{account_id}+{count}+{unit_def_id}`), DJB hash lockstep, the 12-stale-file caveat for battle internals.
+3. [`bsf-client/docs/reference-codebases.md`](./bsf-client/docs/reference-codebases.md) — guide to the three client mirrors under `%USERPROFILE%\Code\bsf-refs\` and the decision tree for which one to read.

--- a/bsf-server/CLAUDE.md
+++ b/bsf-server/CLAUDE.md
@@ -193,7 +193,7 @@ Quick anchors when working in this repo (all under `%USERPROFILE%\Code\bsf-refs\
 - **Lobby** — `tbs/srv/web/svc/lobby/LobbySvc.java` (8 sub-endpoints: `invite`, `uninvite`, `exit`, `join`, `decline`, `options`, `ready`, `unready`) plus its backing state in `tbs/srv/util/LobbySystem.java`. Port target for M3b (Blocker #9).
 - **Schema** — `db/game/0/schema.sql` plus numbered `apply.sql` migrations under `db/game/N/`. Reference column set when adding SQLite tables; not for direct port (MySQL → SQLite syntax differences).
 
-For a one-screen route-by-route map of each `bsf-server` route to its Java `*Svc.java` counterpart and milestone status, see [`docs/protocol-cross-reference.md`](docs/protocol-cross-reference.md). Full milestone plan: [`misc/Plan-Integrate-Original-Stoic-Server.md`](misc/Plan-Integrate-Original-Stoic-Server.md).
+For a one-screen route-by-route map of each `bsf-server` route to its Java `*Svc.java` counterpart and milestone status, see [`docs/protocol-cross-reference.md`](docs/protocol-cross-reference.md). The client-side equivalent — what the AS3 client sends and expects on each route — is [`../bsf-client/docs/wire-protocol.md`](../bsf-client/docs/wire-protocol.md). Full milestone plan: [`misc/Plan-Integrate-Original-Stoic-Server.md`](misc/Plan-Integrate-Original-Stoic-Server.md).
 
 **Working rule:** when adding a route or changing a wire shape, cross-check against the Java reference and the captures in `data/game_captures/`. The reference is the source of truth when they conflict.
 

--- a/bsf-server/docs/doc-gaps.md
+++ b/bsf-server/docs/doc-gaps.md
@@ -33,7 +33,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-client\docs\battle-engine.md` — client-side correspondence (newly written).
   - `bsf-server/data/game_captures/` — Fiddler captures with real-world payloads.
 - **Priority.** P1 — the client docs ([`battle-engine.md`](../../bsf-client/docs/battle-engine.md)) reference `dataStructures.md` for the JSON shapes; readers will land on a WIP page.
-- **Tracking.** _(to be filled with issue URL — see step 11)_
+- **Tracking.** [#74](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/74)
 
 ### 2. Database schema reference
 
@@ -47,7 +47,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/src/db/account.ts`, `ranking.ts`, `battles.ts` — column-using code.
   - `bsf-refs\server-2013-java\db\game\0\schema.sql` — original MySQL schema 88 as a target column set comparison.
 - **Priority.** P1 — newer tables (`ranking`, `battle`) shipped recently and contributors have no place to read about them without grepping migrations.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#75](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/75)
 
 ### 3. Migration design guide
 
@@ -60,7 +60,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/scripts/copy-migrations.js` — build copy step.
   - `bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md` — deferred M1.5 transaction-conflict cleanup.
 - **Priority.** P1 — M1.5 + M2 + M3a all add migrations; a wrong migration in any of them could break startup for everyone.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#76](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/76)
 
 ---
 
@@ -77,7 +77,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/src/login/discord/` — OAuth error codes.
   - `bsf-client/docs/wire-protocol.md` → "Long-poll mechanics" — client-side rules.
 - **Priority.** P2 — useful for debugging client-server interaction issues.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#77](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/77)
 
 ### 5. Security boundaries
 
@@ -92,7 +92,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `.claude/rules/gotchas.md` — `"11"` sentinel, session-key width.
   - `bsf-server/CLAUDE.md` — JWT_SECRET fail-fast.
 - **Priority.** P2 — important for contributors adding new public routes.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#78](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/78)
 
 ### 6. Battle simulation rules
 
@@ -106,7 +106,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-client\client-decompiled-as3\engine\battle\sim\` — client mirror.
   - `bsf-client/docs/battle-engine.md` — client-side FSM + hash.
 - **Priority.** P2 — needed for anyone debugging battle desyncs or porting M1.5+ features.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#79](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/79)
 
 ---
 
@@ -122,7 +122,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `.claude/rules/gotchas.md`.
   - `bsf-server/docs/Development.md` § Key Gotchas.
 - **Priority.** P3 — consolidation work; nothing is broken without it.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#80](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/80)
 
 ### 8. Observability runbook
 
@@ -134,7 +134,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/CHANGELOG.md` 2026-05-11 entries.
   - The perf audit memory (`project_perf_audit_2026_05_11.md`) — orphan-battle leak punch list.
 - **Priority.** P3 — useful for ops; not blocking new features.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#81](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/81)
 
 ### 9. Module READMEs under `src/services/`
 
@@ -145,7 +145,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - The directory contents themselves.
   - `bsf-server/docs/ARCHITECTURE.md` — already has per-module prose to seed from.
 - **Priority.** P3 — small docs; mostly orientation aid for new contributors browsing the tree.
-- **Tracking.** _(to be filled)_
+- **Tracking.** [#82](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/82)
 
 ---
 

--- a/bsf-server/docs/doc-gaps.md
+++ b/bsf-server/docs/doc-gaps.md
@@ -58,7 +58,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/src/db/migrations.ts` — runner implementation.
   - `bsf-server/src/db/migrations/*.sql` — example migrations.
   - `bsf-server/scripts/copy-migrations.js` — build copy step.
-  - `bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md` — deferred M1.5 transaction-conflict cleanup.
+  - `bsf-server/.claude/rules/db.md` — the "no BEGIN/COMMIT inside a migration" rule (added in M1.5).
 - **Priority.** P1 — M1.5 + M2 + M3a all add migrations; a wrong migration in any of them could break startup for everyone.
 - **Tracking.** [#76](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/76)
 
@@ -74,7 +74,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
 - **Source material.**
   - `bsf-server/src/index.ts` — session-key middleware (`/services/auth/login/11` sentinel, `/services/session/steam/overlay/...` allowlist, 403 fallthrough).
   - `bsf-server/src/services/auth/`, `services/battle/`, `services/queue.ts` — per-route error branches.
-  - `bsf-server/src/login/discord/` — OAuth error codes.
+  - `bsf-server/src/services/auth/discord.ts` — OAuth error codes.
   - `bsf-client/docs/wire-protocol.md` → "Long-poll mechanics" — client-side rules.
 - **Priority.** P2 — useful for debugging client-server interaction issues.
 - **Tracking.** [#77](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/77)
@@ -87,7 +87,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
 - **Source material.**
   - `bsf-server/src/index.ts` — middleware order, rate-limit.
   - `bsf-server/src/services/auth/auth.ts` — session-key generation.
-  - `bsf-server/src/login/discord/` — OAuth state cookie.
+  - `bsf-server/src/services/auth/discord.ts` — OAuth state cookie.
   - `bsf-server/CHANGELOG.md` — security-flavored entries.
   - `.claude/rules/gotchas.md` — `"11"` sentinel, session-key width.
   - `bsf-server/CLAUDE.md` — JWT_SECRET fail-fast.
@@ -103,7 +103,7 @@ Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs
   - `bsf-server/src/services/battle/Battle.ts` — server-side battle state.
   - `bsf-server/src/services/battle/` — turn handling.
   - `bsf-refs\server-2013-java\src\main\java\tbs\srv\battle\` — authoritative original logic.
-  - `bsf-client\client-decompiled-as3\engine\battle\sim\` — client mirror.
+  - `bsf-refs\client-decompiled-as3\engine\battle\sim\` — client mirror.
   - `bsf-client/docs/battle-engine.md` — client-side FSM + hash.
 - **Priority.** P2 — needed for anyone debugging battle desyncs or porting M1.5+ features.
 - **Tracking.** [#79](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/issues/79)

--- a/bsf-server/docs/doc-gaps.md
+++ b/bsf-server/docs/doc-gaps.md
@@ -1,0 +1,176 @@
+# Server documentation gaps
+
+## Co-Authored-By: Claude <noreply@anthropic.com>
+
+A tracked inventory of documentation gaps in `bsf-server/`. Each entry lists what's missing, what already exists that the author can draw on, where the new doc should live, and the GitHub issue it's tracked in.
+
+This doc is the **human-readable index**. The actionable units are the linked issues — close issues when the gap is filled, not by editing this file.
+
+## How this list was generated
+
+By auditing `bsf-server/docs/`, `bsf-server/CONTRIBUTING.md`, `bsf-server/CHANGELOG.md`, `.claude/rules/`, and the `Development.md` / `gameFlow.md` / `dataStructures.md` files against the topics a new contributor or an LLM agent realistically needs answers to. Gaps were filtered to "actionable enough that the source material already exists somewhere" — pure wishlist items were dropped.
+
+Companion to the client-side suite at [`bsf-client/docs/`](../../bsf-client/docs/).
+
+## Priority legend
+
+- **P1** — write next. Either a doc is marked WIP and abandoned, or the missing knowledge is required for current-milestone work (M1.5 / M2).
+- **P2** — write after P1 is clear. Important for new contributors and for hardening, but not blocking work in flight.
+- **P3** — nice to have. Mostly consolidation of existing tribal knowledge into a single discoverable place.
+
+---
+
+## P1 gaps
+
+### 1. Battle-message wire formats — finish `dataStructures.md` WIP
+
+- **Current state.** `bsf-server/docs/dataStructures.md` is marked WIP at the top and has been since 2026-05-07. Several battle messages are present only as stubs or missing entirely: `BattleQueryData`, `BattleSurrenderData`, `BattleFinishedData`, `RenownMessage`, `AchievementProgressData`, `ServerStatusData`, `BattleExitData`.
+- **Recommended location.** Finish in place — extend `bsf-server/docs/dataStructures.md` rather than splitting.
+- **Scope.** For each missing/stub message: JSON shape with field types, which routes produce/consume it, when it's pushed (POST response vs `/services/game` long-poll), and the corresponding `tbs.srv.battle.data.client.*Data` class in `bsf-refs\server-2013-java\src\main\java\tbs\srv\battle\data\client\`. Same level of detail as the existing `BattleReadyData` / `BattleDeployData` / `BattleSyncData` sections.
+- **Source material.**
+  - `bsf-server/src/services/battle/Battle.ts` — where each message is produced.
+  - `bsf-refs\server-2013-java\src\main\java\tbs\srv\battle\data\client\` — authoritative Java DTOs.
+  - `bsf-client\docs\battle-engine.md` — client-side correspondence (newly written).
+  - `bsf-server/data/game_captures/` — Fiddler captures with real-world payloads.
+- **Priority.** P1 — the client docs ([`battle-engine.md`](../../bsf-client/docs/battle-engine.md)) reference `dataStructures.md` for the JSON shapes; readers will land on a WIP page.
+- **Tracking.** _(to be filled with issue URL — see step 11)_
+
+### 2. Database schema reference
+
+- **Current state.** No schema reference doc exists. `bsf-server/src/db/schema.sql` is documentation-by-DDL for the legacy `accounts` and `battles` tables, but the newer `ranking`, `battle`, and `schema_version` tables live only in migration files under `src/db/migrations/`. CLAUDE.md mentions both but does not enumerate columns.
+- **Recommended location.** New `bsf-server/docs/database-schema.md`.
+- **Scope.** One section per table: column list with types, NOT NULL / DEFAULT, primary key, foreign keys, indexes, the writer functions in `src/db/*.ts`, the readers that depend on it. Plus a single ER diagram (textual ASCII or Mermaid).
+- **Source material.**
+  - `bsf-server/src/db/schema.sql` — `accounts` + legacy `battles`.
+  - `bsf-server/src/db/migrations/*.sql` — `ranking`, `battle`, `schema_version`.
+  - `bsf-server/src/db/connection.ts` — startup auto-init order.
+  - `bsf-server/src/db/account.ts`, `ranking.ts`, `battles.ts` — column-using code.
+  - `bsf-refs\server-2013-java\db\game\0\schema.sql` — original MySQL schema 88 as a target column set comparison.
+- **Priority.** P1 — newer tables (`ranking`, `battle`) shipped recently and contributors have no place to read about them without grepping migrations.
+- **Tracking.** _(to be filled)_
+
+### 3. Migration design guide
+
+- **Current state.** No design doc for the migration system. `src/db/migrations.ts` has implementation comments but no contributor-facing rules about when to add a migration, naming conventions, idempotency requirements, or how to test one. The plan in `bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md` flagged a deferred M1.5 cleanup item about migrations opening their own transaction conflicting with the runner's outer transaction; that gotcha has no permanent home today.
+- **Recommended location.** New `bsf-server/docs/database-migrations.md`.
+- **Scope.** When to add a `NNN_*.sql` file, the numeric ordering rule, idempotency expectations (the runner uses `schema_version` to skip already-applied migrations but the migration SQL itself should still be `CREATE TABLE IF NOT EXISTS` / `INSERT OR IGNORE`-style), the "do not `BEGIN`/`COMMIT` inside a migration" rule, how `:memory:` testing works, and the `scripts/copy-migrations.js` build step that copies SQL into `build/db/migrations/`.
+- **Source material.**
+  - `bsf-server/src/db/migrations.ts` — runner implementation.
+  - `bsf-server/src/db/migrations/*.sql` — example migrations.
+  - `bsf-server/scripts/copy-migrations.js` — build copy step.
+  - `bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md` — deferred M1.5 transaction-conflict cleanup.
+- **Priority.** P1 — M1.5 + M2 + M3a all add migrations; a wrong migration in any of them could break startup for everyone.
+- **Tracking.** _(to be filled)_
+
+---
+
+## P2 gaps
+
+### 4. Error-code reference
+
+- **Current state.** HTTP error semantics are scattered across `src/index.ts` (the session-key middleware returning 403), individual route handlers (most return 400 on bad input, some return 500 on DB write failures), and the Discord OAuth code path (501 today for the unwired `/login/discord/session`). The client treats 500 as alive and `>= 401 && != 500` as error (`HttpCommunicator.as:43–50` — see [`bsf-client/docs/wire-protocol.md`](../../bsf-client/docs/wire-protocol.md#long-poll-mechanics)). No central reference says when which code fires.
+- **Recommended location.** New `bsf-server/docs/error-handling.md`.
+- **Scope.** Table of HTTP status codes the server emits, which route + condition fires each, the JSON shape the client sees, and the client-side handler's behavior (the 401-vs-500 distinction matters). Plus the conventions for `try/catch` in route handlers and what gets logged.
+- **Source material.**
+  - `bsf-server/src/index.ts` — session-key middleware (`/services/auth/login/11` sentinel, `/services/session/steam/overlay/...` allowlist, 403 fallthrough).
+  - `bsf-server/src/services/auth/`, `services/battle/`, `services/queue.ts` — per-route error branches.
+  - `bsf-server/src/login/discord/` — OAuth error codes.
+  - `bsf-client/docs/wire-protocol.md` → "Long-poll mechanics" — client-side rules.
+- **Priority.** P2 — useful for debugging client-server interaction issues.
+- **Tracking.** _(to be filled)_
+
+### 5. Security boundaries
+
+- **Current state.** Several security-relevant facts are documented as bullets in different places — `.claude/rules/gotchas.md`, `bsf-server/CLAUDE.md`, the M1.5 phase changelog — but no single doc explains the threat model and the boundaries the server currently enforces.
+- **Recommended location.** New `bsf-server/docs/security.md`.
+- **Scope.** Login rate-limit (5/min/IP — already shipped), session key entropy (32 hex chars / 128 bits since 2026-05-08; issue #53), CSRF posture on Discord OAuth (the `bsf_oauth_state` HttpOnly cookie), SQL-injection posture (prepared statements via `node:sqlite`, no string concatenation), the hardcoded `"11"` login sentinel and what it actually allows, `/debug/*` gating + the loud warning when it's exposed (commit `7ca6c1d`), JWT vs session-key model. End with "what is **not** protected today" so contributors know where the boundary actually is.
+- **Source material.**
+  - `bsf-server/src/index.ts` — middleware order, rate-limit.
+  - `bsf-server/src/services/auth/auth.ts` — session-key generation.
+  - `bsf-server/src/login/discord/` — OAuth state cookie.
+  - `bsf-server/CHANGELOG.md` — security-flavored entries.
+  - `.claude/rules/gotchas.md` — `"11"` sentinel, session-key width.
+  - `bsf-server/CLAUDE.md` — JWT_SECRET fail-fast.
+- **Priority.** P2 — important for contributors adding new public routes.
+- **Tracking.** _(to be filled)_
+
+### 6. Battle simulation rules
+
+- **Current state.** `bsf-server/docs/gameFlow.md` covers the battle **lifecycle** (route order, when each message fires) but not the **simulation rules** (turn order computation, move legality, ability resolution, damage formula). Today these rules exist only in `src/services/battle/Battle.ts` and friends. The client has a mirror in `engine/battle/sim/` for legality checks, but the server is authoritative.
+- **Recommended location.** New `bsf-server/docs/battle-simulation.md`.
+- **Scope.** Turn-order computation (who goes first, alternation rules with party-size imbalance), move legality (range, blocked tiles), action legality (ability targeting rules), damage resolution (strength vs armor, willpower exertion, shield bonuses), kill conditions, the per-turn DJB hash and what's hashed. Cross-link to [`bsf-client/docs/battle-engine.md`](../../bsf-client/docs/battle-engine.md) for the client-side hash mechanics.
+- **Source material.**
+  - `bsf-server/src/services/battle/Battle.ts` — server-side battle state.
+  - `bsf-server/src/services/battle/` — turn handling.
+  - `bsf-refs\server-2013-java\src\main\java\tbs\srv\battle\` — authoritative original logic.
+  - `bsf-client\client-decompiled-as3\engine\battle\sim\` — client mirror.
+  - `bsf-client/docs/battle-engine.md` — client-side FSM + hash.
+- **Priority.** P2 — needed for anyone debugging battle desyncs or porting M1.5+ features.
+- **Tracking.** _(to be filled)_
+
+---
+
+## P3 gaps
+
+### 7. FAQ / troubleshooting
+
+- **Current state.** Gotchas and FAQ-style notes are spread across at least three places: `bsf-server/CONTRIBUTING.md § Common Gotchas`, `.claude/rules/gotchas.md`, and `bsf-server/docs/Development.md § Key Gotchas`. There is duplication, drift, and no single place a new contributor lands.
+- **Recommended location.** New `bsf-server/docs/FAQ.md`.
+- **Scope.** Consolidate the three lists. Each entry: one-line problem statement → root cause → fix. Tag entries by area (DB, sessions, battle, deployment). Keep the existing source files as redirect stubs that link to the FAQ.
+- **Source material.**
+  - `bsf-server/CONTRIBUTING.md` § Common Gotchas.
+  - `.claude/rules/gotchas.md`.
+  - `bsf-server/docs/Development.md` § Key Gotchas.
+- **Priority.** P3 — consolidation work; nothing is broken without it.
+- **Tracking.** _(to be filled)_
+
+### 8. Observability runbook
+
+- **Current state.** Log-prefix conventions exist (`[BATTLE]`, `[MATCHMAKING]`, `[AUTH]`, `[QUEUE]`, etc. — visible in any console output) but there is no doc for them and no metrics / alerts / dashboards. The 2026-05-11 perf audit (commit `94d7eea`) identified an orphan-battle leak partly because nobody knew which log channel to grep.
+- **Recommended location.** New `bsf-server/docs/observability.md`.
+- **Scope.** Log-prefix conventions table (one row per prefix, with example lines and what to grep for). The (currently empty) metrics + alert section as a placeholder for future work. Runbooks for the three known degraded states: orphan battles, stuck queue, long-poll deadlock.
+- **Source material.**
+  - `bsf-server/src/` — grep for `console.log` prefixes.
+  - `bsf-server/CHANGELOG.md` 2026-05-11 entries.
+  - The perf audit memory (`project_perf_audit_2026_05_11.md`) — orphan-battle leak punch list.
+- **Priority.** P3 — useful for ops; not blocking new features.
+- **Tracking.** _(to be filled)_
+
+### 9. Module READMEs under `src/services/`
+
+- **Current state.** No `README.md` lives inside any subdirectory of `src/`. Module-level orientation (what's in `src/services/battle/` vs `src/services/queue/` vs `src/db/`) is implicit — readers infer it from file names.
+- **Recommended location.** Three new files: `bsf-server/src/services/battle/README.md`, `bsf-server/src/services/queue/README.md`, `bsf-server/src/db/README.md`.
+- **Scope.** Each README is ~30–50 lines. Per directory: a 2–3 sentence overview, a file-by-file table (`file | role`), pointers to the relevant `docs/` files for deeper material, gotchas specific to that module.
+- **Source material.**
+  - The directory contents themselves.
+  - `bsf-server/docs/ARCHITECTURE.md` — already has per-module prose to seed from.
+- **Priority.** P3 — small docs; mostly orientation aid for new contributors browsing the tree.
+- **Tracking.** _(to be filled)_
+
+---
+
+## What is **not** in this list
+
+Gaps that were considered and rejected — recorded here so they don't keep getting re-raised:
+
+- **A protocol overview / "how the wire works" 101 doc.** Already covered by [`bsf-server/docs/ARCHITECTURE.md`](./ARCHITECTURE.md) → "Endpoint Transport Map" + [`protocol-cross-reference.md`](./protocol-cross-reference.md) + [`bsf-client/docs/wire-protocol.md`](../../bsf-client/docs/wire-protocol.md). The cross-link triad is sufficient.
+- **CI / deployment guide.** [`bsf-server/docs/Deployment.md`](./Deployment.md) exists and is current.
+- **A history / changelog page.** [`bsf-server/CHANGELOG.md`](../CHANGELOG.md) is the single source of truth; [`bsf-server/docs/HISTORY.md`](./HISTORY.md) covers older context.
+- **API reference.** [`serverEndpoints.md`](./serverEndpoints.md) is comprehensive for request/response shapes.
+- **Frontend / client docs.** Tracked separately under [`bsf-client/docs/`](../../bsf-client/docs/).
+
+---
+
+## Working with this file
+
+When you close a gap:
+
+1. Land the new doc.
+2. Edit this file to **remove** the entry (not strike-through it). Keep the table compact.
+3. Comment + close the corresponding GitHub issue.
+
+When you add a new gap:
+
+1. Open a GitHub issue first (`gh issue create --label documentation --label P1/P2/P3`).
+2. Add an entry to this file referencing the issue URL.
+3. Source material citations are mandatory — if no existing artifact informs the gap, it's not actionable enough yet.

--- a/bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md
+++ b/bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md
@@ -10,6 +10,8 @@ _**M2 shipped 2026-05-21** — matchmaking math ported from `tbs.srv.worker.VsWo
 
 _**M1.5 shipped 2026-05-20** (Batches 1+2+3) — five award types ported from `BattleMonitor.constructBattleFinishedData` with Java-parity values: WIN (5), KILLS (1 per enemy unit), UNDERDOG (cap 4), EXPERT (2 for ≤30s win), STREAK (1 if pre-battle win_streak ≥ 2 and party power ≥ 6). A plain three-kill win now pays 8 renown (was 29). `BSF_RENOWN_LEGACY_FORMULA=true` env var flips back to the flat `20 + kills × 3` formula for instant rollback. 19 new parity tests in `src/services/battle/renownAwards.test.ts`; manual 2-player match confirmed end-to-end. DAILY, BOOST, FRIEND deferred indefinitely — they depend on infrastructure bsf-server doesn't have yet (a daily-login counter, an unlocks table, a friend-battle-record table); the wire shape still accepts those keys so no client work is wasted when they land. Elo-on-screen split into a separate M1.6 — `BattleFinishedData.as` has no Elo field today, so surfacing the new rating needs investigation of `AccountInfoData` push vs queue-state refresh. **Bug found during manual test (fixed in the same milestone):** `BattleFinishedData.rewards[]` had been ordered "winner first, loser second" since the array was first written, but the client at `engine/battle/fsm/state/BattleStateFinished.as:32` reads `rewards[localBattleOrder]` (= the local player's `party_index`). Pre-M1.5 the bug was invisible because the loser's slot only held `KILLS = N × 3`; M1.5's per-bonus icons made it loud. The array is now indexed by `party_index`. **Batch 3 cleanup landed in the same milestone**: `ranking.best_win_streak` is now populated by `applyBattleRankingUpdate` on every win, `scripts/copy-migrations.js` has an `existsSync` guard around the source-folder read, and the rule that migration `.sql` files must not contain their own `BEGIN`/`COMMIT` is now documented in `bsf-server/.claude/rules/db.md`._
 
+_**Companion client-docs suite 2026-05-20** — the `bsf-client/docs/` doc suite (landing via the `client-comprehensive-suite` PR) is the authoritative client-side mirror of the route table. Its [`wire-protocol.md`](../../bsf-client/docs/wire-protocol.md) pairs route-by-route with this repo's [`docs/protocol-cross-reference.md`](../docs/protocol-cross-reference.md); its [`battle-engine.md`](../../bsf-client/docs/battle-engine.md) and [`reference-codebases.md`](../../bsf-client/docs/reference-codebases.md) cite the same 12-stale-file caveat used here. Three documented "n/a on bsf-server" exceptions (`account/tutorial` → M3a, `roster/unit/variation` → out of scope per the bullet below, `tourney/join` → M7+) are the only mismatches in either direction — verified by side-by-side count on 2026-05-20._
+
 ## Context
 
 We now have the **original 2013-era Banner Saga Factions server** source at
@@ -230,6 +232,16 @@ Each line is one piece to read, port, and parity-test.
   at `%USERPROFILE%\Code\bsf-refs\client-2013-as3\` (alongside the live decompile
   at `%USERPROFILE%\Code\bsf-refs\client-decompiled-as3\` and the `bsf-client`
   submodule). Do not vendor any of them into BSF.
+- **`POST /services/roster/unit/variation/{id}/{x}/{y}`** — the client's
+  `UnitVariationTxn.as` issues this call for per-unit cosmetic appearance
+  variants (head/clothing swaps); the original Java handler is
+  `tbs/srv/web/svc/roster/unit/variation/UnitVariationSvc.java`. **Out of
+  scope indefinitely.** It's a 2013 Stoic monetization hook with no live shop
+  attached today, no gameplay impact, and the client already tolerates the
+  404 silently (one of three documented "n/a on bsf-server" exceptions in
+  [`docs/protocol-cross-reference.md`](../docs/protocol-cross-reference.md)
+  and [`bsf-client/docs/wire-protocol.md`](../../bsf-client/docs/wire-protocol.md)).
+  Revisit only if/when a real cosmetic system lands.
 
 ---
 
@@ -466,7 +478,10 @@ A fresh Claude session can pick this up cold. Read in this order:
    followed for every edit.
 3. **`bsf-server/.claude/rules/gotchas.md`** — short list of footguns
    (32-bit `account_id`, session-key width, session reaper, etc.).
-4. **`bsf-server/misc/Codebase-Review-Findings-2026-05-07.md`** — current
+4. **`bsf-client/docs/wire-protocol.md`** — client-side route reference; the
+   cleanest map of "what does the client send and expect on each `/services/*`
+   route." Pairs row-by-row with `bsf-server/docs/protocol-cross-reference.md`.
+5. **`bsf-server/misc/Codebase-Review-Findings-2026-05-07.md`** — current
    blocker status (blockers #1–#6 shipped, #7–#10 open).
 
 ### Where to start


### PR DESCRIPTION
## Summary

- Add `bsf-server/docs/doc-gaps.md` as a visible inventory of missing server documentation, with each gap tracked back to a GitHub issue (#74–#82) so anyone can move from inventory → actionable issue or back.
- Cross-link the companion `bsf-client/docs/` suite (landing in eltaino1/BSF-Client#5) from the three places a fresh contributor would look first: workspace-root `REFERENCE.md`, `bsf-server/CLAUDE.md` "Reference server" section, and the top of the integration plan.
- Decide and record `roster/unit/variation` (cosmetic unit-appearance variants) as **out of scope indefinitely** — closes the only remaining "n/a on bsf-server" route the integration plan was silent on.

## Test plan

- [ ] `yarn build` passes (pre-commit hook ran clean on the final commit — 172 tests).
- [ ] `yarn test` passes.
- [ ] Open `BSF/REFERENCE.md`, `bsf-server/CLAUDE.md`, and `bsf-server/misc/Plan-Integrate-Original-Stoic-Server.md` and confirm all three cross-links to `bsf-client/docs/wire-protocol.md` resolve (the file will be present once the companion client PR merges).
- [ ] Open `bsf-server/docs/doc-gaps.md` and confirm each "Tracking" line links to an open issue (#74–#82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)