### PR TITLE
Bump bsf-client + document cross-repo doc link rule (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,28 @@
   - Bad: `C:\Users\rleyb\Code\bsf-refs\client-2013-as3`
 - This keeps docs portable across machines/users and avoids leaking the current username into committed files.
 
+## Cross-Repo Doc Links
+
+When a Markdown link in one published repo (`bsf-server` or `bsf-client`) targets a file in the other, write it in **dual-link** form so it works locally (Ctrl+click in VS Code) **and** on github.com (where each repo is viewed in isolation, with no sibling on disk):
+
+```
+`<path>` ([local](<relative-path>) | [GitHub](https://github.com/Banner-Saga-Factions/<repo>/<blob|tree>/<branch>/<path>))
+```
+
+- **Why**: relative paths like `../../bsf-server/...` resolve under the parent BSF/ checkout but 404 on github.com — the standalone repo has no sibling.
+- **`[local]`** keeps Ctrl+click navigation working in VS Code; **`[GitHub]`** is what github.com readers follow.
+- **Files use `/blob/<branch>/`**; **directories use `/tree/<branch>/`**.
+- **Branch is the _other_ repo's default**: `BSF-Custom-Server` → `main`, `BSF-Client` → `master`.
+- If the file doesn't exist on the other side, drop the reference — don't ship a link that 404s in either context.
+
+Example (from `bsf-client/docs/wire-protocol.md`):
+
+```markdown
+See `bsf-server/docs/protocol-cross-reference.md` ([local](../../bsf-server/docs/protocol-cross-reference.md) | [GitHub](https://github.com/Banner-Saga-Factions/BSF-Custom-Server/blob/main/bsf-server/docs/protocol-cross-reference.md)).
+```
+
+Reference: BSF-Client issue #6 / PR #10 converted the existing docs to this pattern.
+
 ## Reference Codebases
 
 Read-only reference material lives outside the BSF repo at `%USERPROFILE%\Code\bsf-refs\`. None of these are built or shipped; they exist to help reverse-engineer client behavior, understand the wire protocol, and port original-server features.


### PR DESCRIPTION
## Summary

Two related changes from the dead-link work on issue #6:

### 1. Submodule bump

`bsf-client` moves `31597b0 -> d75a885` to pick up [BSF-Client PR #10](https://github.com/Banner-Saga-Factions/BSF-Client/pull/10), which converted every cross-repo link in the client docs to the **dual-link** form:

\`\`\`
text ([local](../../bsf-server/...) | [GitHub](https://github.com/.../bsf-server/...))
\`\`\`

Local link preserves Ctrl+click navigation in VS Code; GitHub link is what github.com readers follow. Both work everywhere.

### 2. Document the convention in root CLAUDE.md

Adds a "Cross-Repo Doc Links" section to root \`CLAUDE.md\` explaining the dual-link form so future Markdown links between \`bsf-server\` and \`bsf-client\` follow the same pattern. Companion bullet in \`bsf-client/CLAUDE.md\` lives in [BSF-Client PR #11](https://github.com/Banner-Saga-Factions/BSF-Client/pull/11).

## Test plan

- [ ] Browse the merged tree on github.com — confirm a few of the \`[GitHub]\` links in \`bsf-client/docs/\` resolve to the right \`bsf-server/...\` file in this repo.
- [ ] Confirm CI / build still passes (one-line submodule bump + doc-only CLAUDE.md change).
- [ ] After merge, open root \`CLAUDE.md\` on github.com → confirm the new "Cross-Repo Doc Links" section renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)