### PR TITLE
Harden the server: opponent token leak, Docker secrets, runaway buffers

### DIFF
--- a/bsf-server/.dockerignore
+++ b/bsf-server/.dockerignore
@@ -1,6 +1,7 @@
 node_modules/
 .git/
 .env
+.env.*
 .claude/
 build/
 data/game_captures/

--- a/bsf-server/CHANGELOG.md
+++ b/bsf-server/CHANGELOG.md
@@ -17,6 +17,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Players no longer receive their opponent's login token mid-match
+
+When a match started, the server sent each player a bundle describing both parties — and that bundle included the *other* player's private session token (the secret that authenticates every request they make). A modified client could read the opponent's token off the wire and act as them for the life of that session. The original Banner Saga Factions server had the same leak.
+
+Why it mattered: a session token is the only thing standing between a player and someone acting as them — queueing, surrendering, spending their renown. Handing it to the one person with an incentive to misuse it (their current opponent) is a real account-safety hole.
+
+The fix blanks that field before the bundle goes out. The game never reads it, so matches start and play exactly as before; the token simply isn't there to steal. We keep the now-empty field so the message still matches the shape the game expects.
+
+*Technical:* `bsf-server/src/services/battle/Battle.ts` — the `BattleCreateData` push in the `Battle` constructor maps `parties` through `{ ...p, session_key: "" }`. `BattlePartyData.session_key` is retained for wire-shape parity with capture `data/game_captures/extracted/raw/0058_s.txt` (asserted keys-only by `matchmaker0058.test.ts`). Stored `battle.parties` values keep the real key (it's the map key); `endgame()` still strips it from `parties_json`. Closes #32.
+
+### Secret environment files can no longer be baked into Docker images
+
+The Docker build copies the whole project into the image. We already excluded the main secrets file (`.env`) but not its variants — a file like `.env.production` holding the real database password would have been embedded into the published image, where anyone who pulled it could extract it.
+
+Why it mattered: secrets in an image layer persist even if the file is later deleted, and layers are easy to inspect. One stray `.env.production` during a build would leak production credentials.
+
+The fix adds those variants to the Docker ignore list so no environment file is ever copied into the build.
+
+*Technical:* `bsf-server/.dockerignore` — added `.env.*` alongside the existing `.env`. Closes #27.
+
+### A disconnected player can no longer slowly eat server memory
+
+Each connected player has a small outbox of messages waiting to be delivered (chat, queue updates, battle events). If a player's game vanished without a clean goodbye — a crash, a yanked cable — the server kept piling messages into that outbox forever, because ongoing broadcasts kept it looking "recently active" and the normal idle-cleanup never kicked in.
+
+Why it mattered: on a small (1 GB) instance, slow unbounded growth like this is exactly what degrades or crashes the process over hours with no obvious culprit.
+
+The fix puts a ceiling on that outbox — 200 messages — dropping the oldest past it. An actively-playing client empties its outbox every few seconds and never gets close, so only a stuck or vanished connection is affected, and the live "new data" signal still fires normally.
+
+*Technical:* `bsf-server/src/services/auth/auth.ts` — `Session.pushData()` trims `this.data` to the new `MAX_SESSION_BUFFER` (200), oldest-first. Regression test in `src/services/auth/auth.test.ts`. Closes #39.
+
 ### Lowering a unit's stats in the barracks no longer wipes the whole change
 
 When a player adjusted a unit's stats in the barracks and *lowered* one of them — willpower or armor break, for example — to move those points into another stat, the change silently failed. The server rejected any stat that was being reduced, and because it checks the entire batch of changes together before saving any of them, one rejected stat threw away the player's whole edit. The unit kept its old stats, so in the next battle every unit looked like it had reset to its defaults. This is what issue #118 reported.

--- a/bsf-server/src/services/auth/auth.test.ts
+++ b/bsf-server/src/services/auth/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { Session, sessionHandler, getInitialData, reapStaleSessions, SESSION_TTL_MS } from "./auth";
+import { Session, sessionHandler, getInitialData, reapStaleSessions, SESSION_TTL_MS, MAX_SESSION_BUFFER } from "./auth";
 import { GameModes, ServerClasses } from "../../const";
 import { battleHandler } from "../battle/Battle";
 
@@ -145,5 +145,31 @@ describe("reapStaleSessions", () => {
         expect(sessionHandler.getSession("session_key", a.session_key)).toBe(a);
         expect(sessionHandler.getSession("session_key", b.session_key)).toBe(b);
         expect(battleHandler.getBattle(battleId)).toBe(battle);
+    });
+});
+
+describe("Session.pushData buffer cap (#39)", () => {
+    it("caps data at MAX_SESSION_BUFFER, drops the oldest, and still emits 'data'", () => {
+        const session = new Session(5000);
+        // Clear the getInitialData() prefill so we only count our own pushes.
+        session.data = [];
+
+        let emitted = 0;
+        session.on("data", () => { emitted++; });
+
+        const overflow = 5;
+        const total = MAX_SESSION_BUFFER + overflow;
+        for (let i = 0; i < total; i++) {
+            session.pushData({ seq: i });
+        }
+
+        // Buffer is bounded to the cap.
+        expect(session.data.length).toBe(MAX_SESSION_BUFFER);
+        // The oldest `overflow` items were dropped — first survivor is seq=overflow,
+        // last is the most recent push.
+        expect(session.data[0].seq).toBe(overflow);
+        expect(session.data[session.data.length - 1].seq).toBe(total - 1);
+        // 'data' still fires on every push so an active poll flushes immediately.
+        expect(emitted).toBe(total);
     });
 });

--- a/bsf-server/src/services/auth/auth.ts
+++ b/bsf-server/src/services/auth/auth.ts
@@ -58,6 +58,11 @@ const getUser = (user_id: number): { username: string } => {
     return _accountsData.find((acc) => acc.user_id === user_id) ?? { username: `player_${user_id}` };
 };
 
+// #39: hard cap on a session's pending-message buffer. Generous enough that an
+// actively-polling client (drains fully every poll) never trips it — only a hung
+// or disconnected session that keeps receiving pushes does.
+export const MAX_SESSION_BUFFER = 200;
+
 export class Session extends EventEmitter {
     display_name: string;
     user_id: number;
@@ -98,6 +103,12 @@ export class Session extends EventEmitter {
     pushData(...data: any) {
         this.lastActivity = Date.now();
         this.data.push(...data);
+        // #39: bound the buffer so a disconnected client that's still being pushed to
+        // (chat/queue broadcasts keep lastActivity fresh, deferring the reaper) can't
+        // grow session memory without limit. Drop the oldest beyond the cap.
+        if (this.data.length > MAX_SESSION_BUFFER) {
+            this.data.splice(0, this.data.length - MAX_SESSION_BUFFER);
+        }
         this.emit("data");
     }
 }

--- a/bsf-server/src/services/battle/Battle.ts
+++ b/bsf-server/src/services/battle/Battle.ts
@@ -18,7 +18,7 @@ const generateBattleId = () => {
 let _debugPartyLimit: number | null = null;
 export function setDebugPartyLimit(n: number | null) { _debugPartyLimit = n; }
 
-let _debugWeakUnits: boolean = false;
+let _debugWeakUnits: boolean = true;
 let _debugFastTimer = process.env.NODE_ENV !== "production";
 export function setDebugWeakUnits(enabled: boolean) { _debugWeakUnits = enabled; }
 export function isDebugWeakUnits(): boolean { return _debugWeakUnits; }
@@ -92,7 +92,12 @@ const validScenes = [
         // List of likely working map scene assets
         const validScenes = [
             "wall",
-        ];
+            "mead_house",
+            "greathall",  
+            "beach",
+            "wall",
+            "proving_grounds",
+            ];
         this.scene = validScenes[Math.floor(Math.random() * validScenes.length)];
 
         let newBattle: BattleData.BattleCreateData = {
@@ -102,7 +107,11 @@ const validScenes = [
             tourney_id: this.tourney_id,
             scene: this.scene,
             friendly: false,
-            parties: Object.values(this.parties),
+            // #32: redact session keys on the wire. The original 2013 server sent each
+            // party's real session_key here (capture 0058_s.txt), leaking the opponent's
+            // auth token. The client never reads the field, so we keep it for wire-shape
+            // parity but blank the value.
+            parties: Object.values(this.parties).map((p: any) => ({ ...p, session_key: "" })),
             ...this.setReliableMessageData("_create"),
         };
 

--- a/bsf-server/src/services/battle/BattlePartyData.ts
+++ b/bsf-server/src/services/battle/BattlePartyData.ts
@@ -11,6 +11,9 @@ export interface BattlePartyData {
     party_index: number;
     elo: number;
     power: number;
+    // Redacted to "" before it goes on the wire (BattleCreateData push) so a player
+    // can't read the opponent's auth token — see the Battle constructor (#32). The
+    // map that holds these objects is keyed by the same value.
     session_key: string;
     battle_count: number;
     tourney_id: number;

--- a/bsf-server/test/routes/battle.test.ts
+++ b/bsf-server/test/routes/battle.test.ts
@@ -325,6 +325,47 @@ describe("POST /battle/surrender/:session_key", () => {
     });
 });
 
+describe("BattleFinishedData.rewards indexed by party_index (#33)", () => {
+    it("a winner at party_index 1 gets their renown at rewards[1], not rewards[0]", async () => {
+        const { a, b, battle } = await createMatch();
+        const aSession = sessionHandler.getSession("session_key", a.session_key)!;
+        const bSession = sessionHandler.getSession("session_key", b.session_key)!;
+
+        // a queued first → party_index 0; b queued second → party_index 1 (earlier-queued
+        // entry takes slot 0, per the CLAUDE.md rewards-ordering invariant).
+        const aIndex = battle.parties[a.session_key].party_index;
+        const bIndex = battle.parties[b.session_key].party_index;
+        expect(aIndex).toBe(0);
+        expect(bIndex).toBe(1);
+
+        // Backdate past the EXPERT (sub-30s) bonus so the winner total is deterministic.
+        battle.startedAt = new Date(Date.now() - 60_000);
+
+        // b (party_index 1) kills both of a's units → b is the winner at slot 1.
+        const body = (entity: string) => ({
+            battle_id: battle.battle_id,
+            entity,
+            turn: 0,
+            ordinal: 0,
+            killedparty: aSession.account_id,
+            killer: "unit1",
+            killerparty: bSession.account_id,
+        });
+        await request(app).post(`/services/battle/killed/${b.session_key}`).send(body("unit1"));
+        await request(app).post(`/services/battle/killed/${b.session_key}`).send(body("unit2"));
+
+        await flushEndgame();
+
+        const finished = bSession.data.find((m: any) => m.class === ServerClasses.BATTLE_FINISHED_DATA);
+        expect(finished).toBeDefined();
+        expect(battle.winner).toBe(bSession.account_id);
+        // Winner b sits at party_index 1: WIN(5)+KILLS(2)=7 must land in slot 1, and the
+        // loser's 0 in slot 0 — proving index-by-party_index, not winner-first.
+        expect(finished.rewards[bIndex].total_renown).toBe(7);
+        expect(finished.rewards[aIndex].total_renown).toBe(0);
+    });
+});
+
 describe("endgame DB writes use steam_id_str not user_id", () => {
     it("addRenown receives the exact Steam ID string, not the precision-lost number", async () => {
         // Use STEAM_ID_BASE + 17 and + 33 — neither is a multiple of 16 (ULP in this


### PR DESCRIPTION
Wave 0 security & resource hardening — issues **#27, #32, #39** — plus a regression test for already-correct reward ordering (**#33**).

## Changes
- **#32 — opponent's session token no longer sent on the wire.** `BattleCreateData` handed each player the opponent's private `session_key` (an auth token). It's now blanked before sending; the client never reads the field, so play is unchanged, and the wire shape still matches the 2013 capture (`matchmaker0058.test.ts`).
- **#27 — secret env files excluded from Docker images.** Added `.env.*` to `.dockerignore` so `.env.production` etc. can't be baked into image layers.
- **#39 — per-session message buffer capped at 200**, dropping oldest-first, so a disconnected client can't grow it without bound.
- **#33 — regression test** pinning `BattleFinishedData.rewards[]` indexing by `party_index` (a winner at `party_index=1` gets their own renown, not the loser's).

## ⚠️ Before merging
This branch also carries two **local debug edits** in `Battle.ts` that should be reverted before merge:
- `_debugWeakUnits = true` — makes every unit in every match weak (STRENGTH 1 / ARMOR 0).
- expanded `validScenes` (mead_house, greathall, beach, proving_grounds) — previously commented out as unconfirmed.

Tests: 264 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)