### PR TITLE
Make the pre-commit test hook reliable on Windows

### DIFF
--- a/bsf-server/vitest.config.ts
+++ b/bsf-server/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
+        // The node:sqlite native module (DatabaseSync) crashes under vitest's default
+        // concurrent child-process forks on Windows ("Worker forks emitted error"),
+        // nondeterministically dropping tests even when every test passes. Run test files
+        // one at a time (still fully isolated) to remove the concurrency that triggers the
+        // crash. Adds a few seconds vs parallel, but makes the pre-commit hook reliable.
+        fileParallelism: false,
         include: ["src/**/*.test.ts", "test/routes/**/*.test.ts", "test/protocol/**/*.test.ts"],
         setupFiles: ["test/setup.ts"],
         testTimeout: 15000,


### PR DESCRIPTION
Independent of the Wave 0 PRs (touches only `vitest.config.ts`) — safe to merge to `main` on its own.

The pre-commit hook runs the full test suite, but vitest's default parallel `forks` pool intermittently crashed a worker on Windows (the `node:sqlite` native module under concurrent child-process forks), blocking commits even when every test passed.

Sets `fileParallelism: false` so test files run one at a time (still fully isolated). Adds a few seconds (~7s → ~15s) for deterministic, reliable runs.

Tests: 264 pass, reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)