### PR TITLE
Pin shell scripts to LF line endings

### DIFF
--- a/bsf-server/.gitattributes
+++ b/bsf-server/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must stay LF so they run on Linux (repo uses core.autocrlf=true,
+# which would otherwise hand them CRLF and break the shebang).
+*.sh text eol=lf


### PR DESCRIPTION
Wave 0 follow-up — a small line-endings hardening.

> 📚 **Stacked on #127** (base branch is `fix/wave0-type-cleanups`).

The repo has `core.autocrlf=true` and no `.gitattributes`, so shell-script line endings depend on each developer's git config. A `.sh` accidentally committed with CRLF fails on the Linux host with a "bad interpreter" error on its shebang.

Adds `bsf-server/.gitattributes` with `*.sh text eol=lf`. Preventive — `start-server.sh` is already LF today; this locks it in and covers future scripts.

(Issues **#44** and **#45** turned out already-complete: `start-server.sh` exists, is executable, LF, and uses the correct `build/index.js` entry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)