### PR TITLE
Turn off the debug weak-units mode that shipped on in production

### DIFF
--- a/bsf-server/CHANGELOG.md
+++ b/bsf-server/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Battles no longer start with every unit weakened
+
+A debug switch meant for local testing — one that strips almost all strength and armor from every unit — had been left turned on in the shipped server, so every match on the live server was being fought with severely weakened units.
+
+Why it mattered: it wasn't a balance change anyone chose; it was a testing aid that escaped into production, so real matches played nothing like the game intends.
+
+The fix turns that switch back off by default. A second fix corrects the developer-only toggle for it, which was backwards — asking to turn weak-units mode "on" actually turned it off, and vice-versa.
+
+*Technical:* `bsf-server/src/services/battle/Battle.ts` — `_debugWeakUnits` default flipped `true`→`false`. `bsf-server/src/app.ts` — `/debug/weak-units` now reads `req.body.enabled === true` (was `=== false`, inverted), matching the correct `/debug/fast-timer` route.
+
 ### Internal cleanups: safer types and a leaner matchmaking lookup
 
 A round of small internal-quality fixes with no change to how the game plays:

--- a/bsf-server/src/app.ts
+++ b/bsf-server/src/app.ts
@@ -50,7 +50,7 @@ if (process.env.NODE_ENV !== "production") {
     });
 
     app.post("/debug/weak-units", (req, res) => {
-        const enabled = req.body?.enabled === false;
+        const enabled = req.body?.enabled === true;
         setDebugWeakUnits(enabled);
         console.log(`[DEBUG] weak units ${enabled ? "ON" : "OFF"}`);
         res.send();

--- a/bsf-server/src/services/battle/Battle.ts
+++ b/bsf-server/src/services/battle/Battle.ts
@@ -19,7 +19,7 @@ const generateBattleId = () => {
 let _debugPartyLimit: number | null = null;
 export function setDebugPartyLimit(n: number | null) { _debugPartyLimit = n; }
 
-let _debugWeakUnits: boolean = true;
+let _debugWeakUnits: boolean = false;
 let _debugFastTimer = process.env.NODE_ENV !== "production";
 export function setDebugWeakUnits(enabled: boolean) { _debugWeakUnits = enabled; }
 export function isDebugWeakUnits(): boolean { return _debugWeakUnits; }
@@ -96,7 +96,6 @@ const validScenes = [
             "mead_house",
             "greathall",  
             "beach",
-            "wall",
             "proving_grounds",
             ];
         this.scene = validScenes[Math.floor(Math.random() * validScenes.length)];


### PR DESCRIPTION
Caught in review while explaining the `/debug/weak-units` route.

Two fixes:
- **Weak-units mode was left on in production.** `_debugWeakUnits` (a local-testing switch that strips strength/armor from every unit) defaulted to `true` on `main`, so every live match ran with weakened units. Flipped back to `false`.
- **The `/debug/weak-units` toggle was inverted.** It read `req.body.enabled === false`, so `{enabled:true}` turned the mode OFF and `{enabled:false}` turned it ON. Now `=== true`, matching the already-correct `/debug/fast-timer`.

Incidental: removed a duplicate `"wall"` entry in the battle scene list.

Tests: 264 pass; pre-commit hook green (no `--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)