### PR TITLE
Add a start-of-session git check to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@
 - **Frontend:** `./bsf-client` (ActionScript/AIR, git submodule of `Banner-Saga-Factions/BSF-Client`)
 - **Reference codebases:** `%USERPROFILE%\Code\bsf-refs\` (read-only, outside repo — see below)
 
+## Start-of-Session Git Check
+
+At the **start of every new or resumed chat**, before doing other work, run a quick git orientation and report it to me up front (keep it to a few lines):
+
+1. **Fetch** remote refs first — read-only and safe: `git fetch` (skip only if offline).
+2. **Active branch:** `git branch --show-current`.
+3. **Sync vs `origin`:** report ahead/behind for the current branch *and* `main`. Call it out explicitly when either is **behind** (needs updating), **ahead** (unpushed commits), or **diverged**.
+4. **Report only — never auto-pull/merge/reset.** My working tree is often dirty and I use stacked branches; if something is out of sync, say so and *offer* to update, then let me decide.
+
+If everything is current, one line is enough (e.g. "On `fix/foo`; it and `main` are in sync with `origin`").
+
 ## Coordination Protocol
 
 1. **Verify Boundaries:** Before changing a server endpoint, search `bsf-client/src/` for the matching `URLLoader` or `URLRequest` to ensure the data structures match.


### PR DESCRIPTION
## What

Adds a **"Start-of-Session Git Check"** section to the repo-root `CLAUDE.md`. At the start of every new or resumed chat, Claude reports the active branch and whether it and `main` are in sync with `origin` (ahead / behind / diverged) **before** doing other work — fetch first, report only, never auto-pull/merge/reset.

## Why

Catches starting work on a stale branch, or not noticing local `main` is several commits behind `origin`, before it causes rework. Prompted by a session where local `main` was 5 commits behind after a PR merged.

## Scope

Docs-only — one section added to `CLAUDE.md` (11 lines), no code changes. The pre-commit build/test hook was intentionally skipped via its own `SKIP_SIMPLE_GIT_HOOKS=1` opt-out (nothing to test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
