### PR TITLE
Stop dismissing a unit from refunding its hire cost (#95)

### DIFF
--- a/bsf-server/CHANGELOG.md
+++ b/bsf-server/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dismissing a unit no longer hands back free renown
+
+Dismissing (retiring) a unit used to refund renown based on the unit's class. But each class has several shop versions at different prices, and the refund always picked the first one — so buying the cheapest version of a class and immediately dismissing it paid back a pricier version's cost, netting free renown on every cycle. A player using direct API calls or a modified client could repeat this to mint renown without limit and distort the whole economy.
+
+Dismissing now refunds only the renown you spent promoting a unit (ranking it up), never its original hire cost — which also matches the original 2013 game, where dismissing refunded nothing. As a paired change, the two archer shop prices that make the exploit visible were restored to their original values (so hiring those costs renown again).
+
+*Technical:* `data/acc.json` (archer cost 0→10, archer_exp 0→25); `src/services/roster.ts` — `computeRetireRefund(rank)` drops the hire-cost term, `/unit/retire` no longer looks up the purchasable template, `/unit/hire` no longer stamps a `purchasable_unit_id` on the unit (that field broke client `/account/info` parsing). Tests in `test/routes/roster.test.ts`. Closes #95.
+
+
 ### Units now earn promotion credit for the kills they make
 
 Previously, a unit's lifetime kill count never went up, no matter how many enemies it defeated in battle. That number is what the game uses to decide when a unit is ready to be promoted, so in practice freshly hired units could never advance past their starting rank — the promote button stayed greyed out forever.

--- a/bsf-server/data/acc.json
+++ b/bsf-server/data/acc.json
@@ -69,7 +69,7 @@
                     "appearance_index": 0
                 },
                 "limit": 0,
-                "cost": 0
+                "cost": 10
             },
             {
                 "class": "tbs.srv.data.PurchasableUnitData",
@@ -318,7 +318,7 @@
                     "appearance_index": 0
                 },
                 "limit": 0,
-                "cost": 0,
+                "cost": 25,
                 "comment": "mh_experienced"
             },
             {

--- a/bsf-server/src/services/roster.ts
+++ b/bsf-server/src/services/roster.ts
@@ -8,10 +8,12 @@ export const RosterRouter = Router();
 
 const MAX_NAME_LEN = 32;
 
-// Inverse of /unit/hire (template.cost) and /unit/promote (20 for 1→2, 80 for 2→3).
-// A rank-3 archer with cost 10 refunds 110; a rank-1 archer refunds 10.
-function computeRetireRefund(hireCost: number, rank: number): number {
-    let refund = hireCost;
+// Refund the renown spent PROMOTING the unit (20 for rank 1→2, 80 for 2→3) — never
+// the hire cost. See the note in /unit/retire (#95): refunding the hire cost let a
+// cheap-variant hire→retire cycle mint renown, and the original game refunded nothing
+// on retire anyway. A rank-3 unit refunds 100; a rank-1 unit refunds 0.
+function computeRetireRefund(rank: number): number {
+    let refund = 0;
     if (rank >= 2) refund += 20;
     if (rank >= 3) refund += 80;
     return refund;
@@ -120,15 +122,14 @@ RosterRouter.post("/unit/retire/:session_key?", async (req, res) => {
     if (idx === -1) { res.sendStatus(404); return; }
     const unit = acc.roster_json[idx];
 
-    // Template lookup by entityClass mirrors /unit/stats/reset — roster units don't store
-    // their original purchasable_unit_id, only the spread `entityClass` from the template.
-    const template = PURCHASABLE_UNITS.units.find((u: any) => u.def.entityClass === unit.entityClass);
-    if (!template) {
-        console.warn("[ROSTER] retire: template missing for entityClass=", unit.entityClass, "— refunding rank-up only");
-    }
-    const hireCost = template?.cost ?? 0;
+    // Refund only the renown spent PROMOTING this unit (rank-up costs) — never the
+    // original hire cost. The original game refunded nothing on retire (UnitRetireSvc
+    // just deletes the unit); bsf-server's hire-cost refund was an addition, and because
+    // a class has several hire prices (archer 10 / archer_exp 25 / archer_vet 0) it let
+    // "hire the cheap variant, then retire" mint renown (#95). The fixed promotion costs
+    // are provably paid, so refunding only those can never net positive.
     const rank = unit.stats.find((s: any) => s.stat === "RANK")?.value ?? 1;
-    const refund = computeRetireRefund(hireCost, rank);
+    const refund = computeRetireRefund(rank);
 
     // Build new arrays without mutating acc until after the DB write succeeds.
     const newRoster = acc.roster_json.filter((_: any, i: number) => i !== idx);

--- a/bsf-server/test/routes/roster.test.ts
+++ b/bsf-server/test/routes/roster.test.ts
@@ -334,13 +334,13 @@ describe("POST /services/roster/unit/retire/:session_key", () => {
         expect(pushed.total).toBe(1100);
     });
 
-    it("refunds rank-up only when the unit's class is no longer in the catalog", async () => {
+    it("refunds promotion renown regardless of entityClass", async () => {
         const { session_key } = await loginPlayer("335");
         const session = sessionHandler.getSession("session_key", session_key)!;
         const acc = session.accountData!;
-        // unit2 is RANK 2. Forcing an unknown entityClass means hire cost can't be verified.
+        // unit2 is RANK 2. entityClass no longer affects the refund (#95: hire cost is
+        // never refunded), so even an unknown class still returns the rank-up renown.
         acc.roster_json.find((u: any) => u.id === "unit2")!.entityClass = "ghost_class";
-        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
         const pushSpy = vi.spyOn(session, "pushData");
 
         const res = await request(app)
@@ -348,15 +348,12 @@ describe("POST /services/roster/unit/retire/:session_key", () => {
             .send({ unit_id: "unit2" });
 
         expect(res.status).toBe(200);
-        expect(acc.renown).toBe(1020);       // hire 0 (unknown) + 20 (rank-up)
+        expect(acc.renown).toBe(1020);       // 20 (rank-up), no hire cost
         expect(acc.roster_json.find((u: any) => u.id === "unit2")).toBeUndefined();
-        expect(warnSpy).toHaveBeenCalled();
 
         expect(pushSpy).toHaveBeenCalledOnce();
         const pushed = pushSpy.mock.calls[0][0] as any;
         expect(pushed.total).toBe(1020);
-
-        warnSpy.mockRestore();
     });
 
     it("still dismisses with no refund when template missing and unit is rank 1", async () => {
@@ -413,6 +410,30 @@ describe("POST /services/roster/unit/retire/:session_key", () => {
         expect(session.accountData!.renown).toBe(prevRenown);
         expect(pushSpy).not.toHaveBeenCalled();
     });
+
+    it("never refunds the hire cost on retire, so hire→retire can't mint renown (#95)", async () => {
+        const { session_key } = await loginPlayer("350");
+        const session = sessionHandler.getSession("session_key", session_key)!;
+        const acc = session.accountData!;
+        acc.renown = 100;
+
+        // Hire a fresh archer — costs 10 after the #95 cost re-arm.
+        const hire = await request(app)
+            .post(`/services/roster/unit/hire/${session_key}`)
+            .send({ purchasable_unit_id: "archer", new_unit_id: "honest_start_0", new_unit_name: "Honest" });
+        expect(hire.status).toBe(200);
+        expect(acc.renown).toBe(90); // paid 10
+
+        const retire = await request(app)
+            .post(`/services/roster/unit/retire/${session_key}`)
+            .send({ unit_id: "honest_start_0" });
+        expect(retire.status).toBe(200);
+
+        // Rank-1 unit → refund is promotion renown only (0), NOT the 10 hire cost.
+        const call = vi.mocked(saveRosterAndAddRenown).mock.calls[0];
+        expect(call[2]).toBe(0);
+        expect(acc.renown).toBe(90); // hire cost is gone — no way to net positive
+    });
 });
 
 // ──────────────────────────────────────────────
@@ -449,9 +470,10 @@ describe("POST /services/roster/unit/hire/:session_key", () => {
         const session = sessionHandler.getSession("session_key", session_key)!;
         session.accountData!.renown = 0;
 
+        // archer_vet still costs 0 after the #95 cost re-arm (archer=10, archer_exp=25).
         const res = await request(app)
             .post(`/services/roster/unit/hire/${session_key}`)
-            .send({ purchasable_unit_id: "archer", new_unit_id: "x_start_0", new_unit_name: "x" });
+            .send({ purchasable_unit_id: "archer_vet", new_unit_id: "x_start_0", new_unit_name: "x" });
         expect(res.status).toBe(200);
     });
 


### PR DESCRIPTION
## What was wrong
Dismissing (retiring) a unit refunded renown based on the unit's class, but each class has several shop versions at different prices and the refund always used the **first** match. So buying the cheapest version of a class and dismissing it paid back a pricier sibling's cost — minting renown every cycle. Reachable via direct API calls or a modified client; a renown-minting primitive that distorts the economy.

## The fix
Dismissing now refunds **only the renown spent promoting** a unit (20 for rank 2, 100 for rank 3), **never the original hire cost**. This is mint-proof by construction regardless of which template was bought, and it matches the original 2013 server, which refunded nothing on retire (`UnitRetireSvc.java` just deletes the unit). As a paired change, the two archer shop costs that make the exploit visible were restored (`archer`=10, `archer_exp`=25).

## Approach note (changed mid-implementation)
The originally-planned fix — store the bought template's id (`purchasable_unit_id`) on each unit and refund by it — was **abandoned**. That field, echoed in `/account/info`, breaks the AS3 client's roster parse (the client falls back to its local cache → stale renown + tutorial replay), and it's wiped anyway when the client POSTs its roster back via `/account/update`. The promotion-renown-only fix needs no per-unit storage and never touches the client wire shape.

A promote `class_id` allowlist was also considered and **dropped** — it would constrain modding while adding no security value once retire stopped keying on `entityClass`.

## Testing
- `yarn build` clean; `yarn test` → **285 tests pass** (incl. a new #95 regression: hire −10 → retire → +0, no way to net positive).
- Live: hire/retire verified in the client.

## Note
The "seas of the network have grown stormy" error seen while testing promotes is **pre-existing #72** (fails on the 2nd color variant; 1st works) — `/unit/promote` is unchanged by this PR.

Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)